### PR TITLE
Fix visible area being clipped by bottom scroll bar

### DIFF
--- a/Code/EntryPoint.cpp
+++ b/Code/EntryPoint.cpp
@@ -134,7 +134,7 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		ScrollInfo.cbSize = sizeof(ScrollInfo);
 		ScrollInfo.fMask = SIF_RANGE | SIF_PAGE;
 		ScrollInfo.nMin = 0;
-		ScrollInfo.nMax = LineCount - 1;
+		ScrollInfo.nMax = LineCount;
 		ScrollInfo.nPage = ClientHeight / CharHeight;
 		SetScrollInfo(WindowHandle, SB_VERT, &ScrollInfo, TRUE);
 


### PR DESCRIPTION
The visible area was clipped because the bottom scroll bar
would cover it. This is because I removed one from the total
line count.

This commit fixes that.

Fixes #6