### PR TITLE
Fix AppVeyor builds

### DIFF
--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj
@@ -23,6 +23,8 @@
     <ClCompile Include="..\..\..\Code\BufferChain.cpp" />
     <ClCompile Include="..\..\..\Code\EntryPoint.cpp" />
     <ClCompile Include="..\..\..\Code\Workspace.cpp" />
+    <ClInclude Include="..\..\..\Code\Buffer.hpp" />
+    <ClInclude Include="..\..\..\Code\BufferChain.hpp" />
     <ClInclude Include="..\..\..\Code\EntryPoint.hpp" />
     <ClInclude Include="..\..\..\Code\Workspace.hpp" />
   </ItemGroup>

--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
@@ -7,12 +7,24 @@
     <ClCompile Include="..\..\..\Code\Workspace.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Code\Buffer.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Code\BufferChain.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\EntryPoint.hpp">
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Code\Workspace.hpp">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Code\Buffer.hpp">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Code\BufferChain.hpp">
       <Filter>Code</Filter>
     </ClInclude>
   </ItemGroup>
@@ -84,12 +96,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\Code\Buffer.hpp">
-      <Filter>Code</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\Code\BufferChain.hpp">
-      <Filter>Code</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\Code\EntryPoint.hpp">
       <Filter>Code</Filter>
     </ClInclude>

--- a/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
+++ b/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
@@ -81,23 +81,23 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>C:\Programming\Projects\maxHex\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\Programming\Projects\maxHex\Projects\VisualStudio\max\$(Platform)\$(PlatformTarget);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
+    <LibraryPath>$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>C:\Programming\Projects\maxHex\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\Programming\Projects\maxHex\Projects\VisualStudio\max\$(Platform)\$(PlatformTarget);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
+    <LibraryPath>$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>C:\Programming\Projects\maxHex\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\Programming\Projects\maxHex\Projects\VisualStudio\max\$(Platform)\$(PlatformTarget);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
+    <LibraryPath>$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>C:\Programming\Projects\maxHex\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>C:\Programming\Projects\maxHex\Projects\VisualStudio\max\$(Platform)\$(PlatformTarget);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
+    <LibraryPath>$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
+++ b/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
@@ -83,6 +83,8 @@
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
     <LibraryPath>$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -93,6 +95,8 @@
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
     <LibraryPath>$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>

--- a/Tooling/AppVeyor/AppVeyor.yml
+++ b/Tooling/AppVeyor/AppVeyor.yml
@@ -26,6 +26,6 @@ configuration:
   - Release
 
 test_script:
-  - "%APPVEYOR_BUILD_FOLDER%/Projects/VisualStudio/maxHexAutomatedTests/%PLATFORM%/%CONFIGURATION%/maxHexAutomatedTests.exe"
+  - "%APPVEYOR_BUILD_FOLDER%/Projects/VisualStudio/%PLATFORM%/%CONFIGURATION%/maxHexAutomatedTests.exe"
   - ps: $wc = New-Object 'System.Net.WebClient'
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\Tooling\AppVeyor\junit-results.xml))

--- a/Tooling/AppVeyor/AppVeyor.yml
+++ b/Tooling/AppVeyor/AppVeyor.yml
@@ -19,7 +19,7 @@ build:
   parallel: true
 
 platform:
-  - x86
+  - Win32
   - x64
 configuration:
   - Debug


### PR DESCRIPTION
The automated tests project uses a fixed directory path rather
than a relative path. As a result, this was building on my local
machine but not on AppVeyor (which used a different directory
structure).

This commit fixes the AppVeyor builds by using a relative path for
includes and libraries.