### PR TITLE
Support multiple buffers

### DIFF
--- a/Code/Buffer.cpp
+++ b/Code/Buffer.cpp
@@ -10,19 +10,21 @@
 namespace maxHex
 {
 
-	Buffer::Buffer(File&& SourceFile, size_t&& SourceOffset, const size_t BufferLength) noexcept
+	Buffer::Buffer(File SourceFile, size_t SourceOffset, const size_t BufferLength, const size_t BufferCapacity) noexcept
 		: SourceFile(std::move(SourceFile))
 		, SourceOffset(std::move(SourceOffset))
-		, ByteBuffer(std::make_unique<char[]>(BufferLength))
+		, ByteBuffer(std::make_unique<char[]>(BufferCapacity))
 		, ByteBufferLength(BufferLength)
+		, ByteBufferCapacity(BufferCapacity)
 	{
 	}
 
 	Buffer::Buffer(const Buffer& rhs) noexcept
 		: SourceFile(rhs.SourceFile)
 		, SourceOffset(rhs.SourceOffset)
-		, ByteBuffer(std::make_unique<char[]>(rhs.ByteBufferLength))
+		, ByteBuffer(std::make_unique<char[]>(rhs.ByteBufferCapacity))
 		, ByteBufferLength(rhs.ByteBufferLength)
+		, ByteBufferCapacity(rhs.ByteBufferCapacity)
 	{
 		std::copy(rhs.ByteBuffer.get(), rhs.ByteBuffer.get() + rhs.ByteBufferLength, ByteBuffer.get());
 	}
@@ -32,6 +34,7 @@ namespace maxHex
 		, SourceOffset(std::move(rhs.SourceOffset))
 		, ByteBuffer(std::move(rhs.ByteBuffer))
 		, ByteBufferLength(std::move(rhs.ByteBufferLength))
+		, ByteBufferCapacity(std::move(rhs.ByteBufferCapacity))
 	{
 		rhs.ByteBuffer = nullptr;
 	}
@@ -40,8 +43,10 @@ namespace maxHex
 	{
 		SourceFile = rhs.SourceFile;
 		SourceOffset = rhs.SourceOffset;
-		ByteBuffer = std::make_unique<char[]>(rhs.ByteBufferLength);
+		ByteBuffer = std::make_unique<char[]>(rhs.ByteBufferCapacity);
 		ByteBufferLength = rhs.ByteBufferLength;
+		ByteBufferCapacity = rhs.ByteBufferCapacity;
+
 		std::copy(rhs.ByteBuffer.get(), rhs.ByteBuffer.get() + rhs.ByteBufferLength, ByteBuffer.get());
 
 		return *this;
@@ -54,6 +59,7 @@ namespace maxHex
 		ByteBuffer = std::move(rhs.ByteBuffer);
 		rhs.ByteBuffer = nullptr;
 		ByteBufferLength = std::move(rhs.ByteBufferLength);
+		ByteBufferCapacity = std::move(rhs.ByteBufferCapacity);
 
 		return *this;
 	}

--- a/Code/Buffer.hpp
+++ b/Code/Buffer.hpp
@@ -15,7 +15,7 @@ namespace maxHex
 	{
 	public:
 
-		Buffer(File&& SourceFile, size_t&& SourceOffset, const size_t BufferLength) noexcept;
+		Buffer(File SourceFile, size_t SourceOffset, const size_t BufferLength, const size_t BufferCapacity) noexcept;
 		Buffer(const Buffer& rhs) noexcept;
 		Buffer(Buffer&& rhs) noexcept;
 		~Buffer() noexcept = default;
@@ -27,6 +27,7 @@ namespace maxHex
 		size_t SourceOffset;
 		std::unique_ptr<char[]> ByteBuffer;
 		size_t ByteBufferLength;
+		size_t ByteBufferCapacity;
 
 	};
 

--- a/Code/BufferChain.cpp
+++ b/Code/BufferChain.cpp
@@ -13,13 +13,13 @@ namespace maxHex
 	{
 	}
 
-	BufferChain::BufferChain(Buffer&& InitialBuffer)
+	BufferChain::BufferChain(Buffer InitialBuffer)
 		: BufferList()
 	{
 		BufferList.push_back(std::move(InitialBuffer));
 	}
 
-	BufferChain::BufferChain(std::vector<Buffer>&& BufferList)
+	BufferChain::BufferChain(std::vector<Buffer> BufferList)
 		: BufferList(std::move(BufferList))
 	{
 	}

--- a/Code/BufferChain.hpp
+++ b/Code/BufferChain.hpp
@@ -16,8 +16,8 @@ namespace maxHex
 	public:
 
 		BufferChain();
-		explicit BufferChain(Buffer&& InitialBuffer);
-		explicit BufferChain(std::vector<Buffer>&& BufferList);
+		explicit BufferChain(Buffer InitialBuffer);
+		explicit BufferChain(std::vector<Buffer> BufferList);
 
 		std::vector<Buffer> BufferList;
 

--- a/Code/BufferChainTests.cpp
+++ b/Code/BufferChainTests.cpp
@@ -30,7 +30,8 @@ namespace maxHex
 			#endif
 			size_t SourceOffset = 0;
 			const size_t BufferLength = 10;
-			Buffer BufferToConsume(std::move(TestFile), std::move(SourceOffset), BufferLength);
+			const size_t BufferCapacity = 20;
+			Buffer BufferToConsume(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
 
 			char const* MemoryLocation = BufferToConsume.ByteBuffer.get();
 
@@ -38,6 +39,7 @@ namespace maxHex
 
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[0].ByteBuffer.get() == MemoryLocation);
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[0].ByteBufferLength == BufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[0].ByteBufferCapacity == BufferCapacity);
 			CurrentTest.MAX_TESTING_ASSERT(BufferToConsume.ByteBuffer == nullptr);
 			}
 		});
@@ -50,12 +52,14 @@ namespace maxHex
 			File SecondTestFile(SecondFilePath);
 			#endif
 			size_t FirstSourceOffset = 0;
-			size_t SecondSourceOffset = 0;
-			const size_t FirstBufferLength = 10;
-			const size_t SecondBufferLength = 20;
+			size_t SecondSourceOffset = 10;
+			const size_t FirstBufferLength = 20;
+			const size_t SecondBufferLength = 30;
+			const size_t FirstBufferCapacity = 40;
+			const size_t SecondBufferCapacity = 50;
 			std::vector<Buffer> BufferListToConsume;
-			BufferListToConsume.emplace_back(std::move(FirstTestFile), std::move(FirstSourceOffset), FirstBufferLength);
-			BufferListToConsume.emplace_back(std::move(SecondTestFile), std::move(SecondSourceOffset), SecondBufferLength);
+			BufferListToConsume.emplace_back(std::move(FirstTestFile), std::move(FirstSourceOffset), FirstBufferLength, FirstBufferCapacity);
+			BufferListToConsume.emplace_back(std::move(SecondTestFile), std::move(SecondSourceOffset), SecondBufferLength, SecondBufferCapacity);
 
 			char const* FirstMemoryLocation = BufferListToConsume[0].ByteBuffer.get();
 			char const* SecondMemoryLocation = BufferListToConsume[1].ByteBuffer.get();
@@ -64,8 +68,10 @@ namespace maxHex
 
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[0].ByteBuffer.get() == FirstMemoryLocation);
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[0].ByteBufferLength == FirstBufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[0].ByteBufferCapacity == FirstBufferCapacity);
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[1].ByteBuffer.get() == SecondMemoryLocation);
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[1].ByteBufferLength == SecondBufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.BufferList[1].ByteBufferCapacity == SecondBufferCapacity);
 			CurrentTest.MAX_TESTING_ASSERT(BufferListToConsume.size() == 0);
 			}
 		});

--- a/Code/BufferTests.cpp
+++ b/Code/BufferTests.cpp
@@ -26,21 +26,24 @@ namespace maxHex
 			#endif
 			size_t SourceOffset = 0;
 			const size_t BufferLength = 10;
-			Buffer TestObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
+			const size_t BufferCapacity = 20;
+			Buffer TestObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
 
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBuffer != nullptr);
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferLength == BufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferCapacity == BufferCapacity);
 		}
 		});
 
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy constructor copies elements", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy constructor copies", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			#if defined(MAX_PLATFORM_WINDOWS)
 			LPCTSTR FilePath = TEXT("Test\\Path");
 			File TestFile(FilePath);
 			#endif
 			size_t SourceOffset = 0;
 			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
+			const size_t BufferCapacity = 20;
+			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
 
 			for (size_t i = 0; i < BufferLength; i++)
 			{
@@ -48,6 +51,8 @@ namespace maxHex
 			}
 
 			Buffer TestObject = OriginalObject;
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferLength == OriginalObject.ByteBufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferCapacity == OriginalObject.ByteBufferCapacity);
 			for (size_t i = 0; i < BufferLength; i++)
 			{
 				CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBuffer[i] == OriginalObject.ByteBuffer[i]);
@@ -55,74 +60,36 @@ namespace maxHex
 		}
 		});
 
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy constructor matches length", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move constructor moves byte", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			#if defined(MAX_PLATFORM_WINDOWS)
 			LPCTSTR FilePath = TEXT("Test\\Path");
 			File TestFile(FilePath);
 			#endif
 			size_t SourceOffset = 0;
 			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
-
-			Buffer TestObject = OriginalObject;
-			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferLength == OriginalObject.ByteBufferLength);
-		}
-		});
-
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move constructor moves byte buffer", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
-			#if defined(MAX_PLATFORM_WINDOWS)
-			LPCTSTR FilePath = TEXT("Test\\Path");
-			File TestFile(FilePath);
-			#endif
-			size_t SourceOffset = 0;
-			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
+			const size_t BufferCapacity = 20;
+			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
 
 			const char* OriginalByteBufferAddress = OriginalObject.ByteBuffer.get();
 
 			Buffer TestObject = std::move(OriginalObject);
 
-			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBuffer.get() == OriginalByteBufferAddress);
-		}
-		});
-
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move constructor nulls old byte buffer", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
-			#if defined(MAX_PLATFORM_WINDOWS)
-			LPCTSTR FilePath = TEXT("Test\\Path");
-			File TestFile(FilePath);
-			#endif
-			size_t SourceOffset = 0;
-			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
-
-			Buffer TestObject = std::move(OriginalObject);
 			CurrentTest.MAX_TESTING_ASSERT(OriginalObject.ByteBuffer == nullptr);
-		}
-		});
-
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move constructor moves byte buffer length", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
-			#if defined(MAX_PLATFORM_WINDOWS)
-			LPCTSTR FilePath = TEXT("Test\\Path");
-			File TestFile(FilePath);
-			#endif
-			size_t SourceOffset = 0;
-			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
-
-			Buffer TestObject = std::move(OriginalObject);
-
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBuffer.get() == OriginalByteBufferAddress);
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferLength == BufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferCapacity == BufferCapacity);
 		}
 		});
 
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy assignment operator copies elements", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy assignment operator copies", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			#if defined(MAX_PLATFORM_WINDOWS)
 			LPCTSTR FilePath = TEXT("Test\\Path");
 			File TestFile(FilePath);
 			#endif
 			size_t SourceOffset = 0;
 			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
+			const size_t BufferCapacity = 20;
+			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
 
 			for (size_t i = 0; i < BufferLength; i++)
 			{
@@ -133,10 +100,15 @@ namespace maxHex
 			LPCTSTR SecondFilePath = TEXT("Test\\Path");
 			File SecondTestFile(SecondFilePath);
 			#endif
-			size_t SecondSourceOffset = 0;
-			Buffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), BufferLength);
+			size_t SecondSourceOffset = 30;
+			const size_t SecondBufferLength = 40;
+			const size_t SecondBufferCapacity = 50;
+			Buffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), SecondBufferLength, SecondBufferCapacity);
 			TestObject = OriginalObject;
 
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceOffset == OriginalObject.SourceOffset);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferLength == OriginalObject.ByteBufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferCapacity == OriginalObject.ByteBufferCapacity);
 			for (size_t i = 0; i < BufferLength; i++)
 			{
 				CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBuffer[i] == OriginalObject.ByteBuffer[i]);
@@ -144,68 +116,33 @@ namespace maxHex
 		}
 		});
 
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy assignment operator matches length", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move assignment operator moves", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			#if defined(MAX_PLATFORM_WINDOWS)
 			LPCTSTR FilePath = TEXT("Test\\Path");
 			File TestFile(FilePath);
 			#endif
 			size_t SourceOffset = 0;
 			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
+			const size_t BufferCapacity = 20;
+			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
+			const char* OriginalByteBufferAddress = OriginalObject.ByteBuffer.get();
 
 			#if defined(MAX_PLATFORM_WINDOWS)
 			LPCTSTR SecondFilePath = TEXT("Test\\Path");
 			File SecondTestFile(SecondFilePath);
 			#endif
-			size_t SecondSourceOffset = 0;
+			size_t SecondSourceOffset = 30;
+			const size_t SecondBufferLength = 40;
+			const size_t SecondBufferCapacity = 50;
 
-			Buffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), BufferLength);
-			TestObject = OriginalObject;
-			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferLength == OriginalObject.ByteBufferLength);
-		}
-		});
+			Buffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), SecondBufferLength, SecondBufferCapacity);
 
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move assignment operator nulls old byte buffer", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
-			#if defined(MAX_PLATFORM_WINDOWS)
-			LPCTSTR FilePath = TEXT("Test\\Path");
-			File TestFile(FilePath);
-			#endif
-			size_t SourceOffset = 0;
-			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
-
-			#if defined(MAX_PLATFORM_WINDOWS)
-			LPCTSTR SecondFilePath = TEXT("Test\\Path");
-			File SecondTestFile(SecondFilePath);
-			#endif
-			size_t SecondSourceOffset = 0;
-
-			Buffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), BufferLength);
 			TestObject = std::move(OriginalObject);
 
 			CurrentTest.MAX_TESTING_ASSERT(OriginalObject.ByteBuffer == nullptr);
-		}
-		});
-
-		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move constructor moves byte buffer length", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
-			#if defined(MAX_PLATFORM_WINDOWS)
-			LPCTSTR FilePath = TEXT("Test\\Path");
-			File TestFile(FilePath);
-			#endif
-			size_t SourceOffset = 0;
-			const size_t BufferLength = 10;
-			Buffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength);
-
-			#if defined(MAX_PLATFORM_WINDOWS)
-			LPCTSTR SecondFilePath = TEXT("Test\\Path");
-			File SecondTestFile(SecondFilePath);
-			#endif
-			size_t SecondSourceOffset = 0;
-
-			Buffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), BufferLength);
-			TestObject = std::move(OriginalObject);
-
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBuffer.get() == OriginalByteBufferAddress);
 			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferLength == BufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.ByteBufferCapacity == BufferCapacity);
 		}
 		});
 

--- a/Code/EntryPoint.cpp
+++ b/Code/EntryPoint.cpp
@@ -120,9 +120,14 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 
 		MaxWidth = 72 * CharWidth; // TODO: Find real value
 
+		size_t TotalSize = 0;
+		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		{
+			TotalSize += CurrentBuffer.ByteBufferLength;
+		}
 		int LineCount = 0;
-		if (TestWorkspace.Buffers.BufferList.size() != 0) {
-			LineCount = (TestWorkspace.Buffers.BufferList[0].ByteBufferLength / 16) + 1;
+		if (TotalSize != 0) {
+			LineCount = (TotalSize / 16) + 1;
 		}
 		SetScrollRange(WindowHandle, SB_VERT, 0, LineCount - 1, FALSE);
 		SetScrollPos(WindowHandle, SB_VERT, 0, TRUE);
@@ -135,9 +140,14 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		return 0;
 	case WM_SIZE:
 	{
+		size_t TotalSize = 0;
+		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		{
+			TotalSize += CurrentBuffer.ByteBufferLength;
+		}
 		int LineCount = 0;
-		if (TestWorkspace.Buffers.BufferList.size() != 0) {
-			LineCount = (TestWorkspace.Buffers.BufferList[0].ByteBufferLength / 16) + 1;
+		if (TotalSize != 0) {
+			LineCount = (TotalSize / 16) + 1;
 		}
 		ClientHeight = HIWORD(lParam);
 		ClientWidth = LOWORD(lParam);
@@ -201,9 +211,14 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		GetScrollInfo(WindowHandle, SB_VERT, &ScrollInfo);
 
 
+		size_t TotalSize = 0;
+		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		{
+			TotalSize += CurrentBuffer.ByteBufferLength;
+		}
 		int LineCount = 0;
-		if (TestWorkspace.Buffers.BufferList.size() != 0) {
-			LineCount = (TestWorkspace.Buffers.BufferList[0].ByteBufferLength / 16);
+		if (TotalSize != 0) {
+			LineCount = TotalSize / 16;
 		}
 		if (VerticalScrollPosition != ScrollInfo.nPos)
 		{
@@ -315,9 +330,14 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		SetScrollInfo(WindowHandle, SB_VERT, &ScrollInfo, TRUE);
 		GetScrollInfo(WindowHandle, SB_VERT, &ScrollInfo);
 
+		size_t TotalSize = 0;
+		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		{
+			TotalSize += CurrentBuffer.ByteBufferLength;
+		}
 		int LineCount = 0;
-		if (TestWorkspace.Buffers.BufferList.size() != 0) {
-			LineCount = (TestWorkspace.Buffers.BufferList[0].ByteBufferLength / 16);
+		if (TotalSize != 0) {
+			LineCount = TotalSize / 16;
 		}
 		if (VerticalScrollPosition != ScrollInfo.nPos)
 		{
@@ -369,9 +389,14 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		HFONT NewFont = (HFONT)GetStockObject(SYSTEM_FIXED_FONT);
 		HFONT OldFont = (HFONT)SelectObject(DeviceContext, NewFont);
 
+		size_t TotalSize = 0;
+		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		{
+			TotalSize += CurrentBuffer.ByteBufferLength;
+		}
 		int LineCount = 0;
-		if (TestWorkspace.Buffers.BufferList.size() != 0) {
-			LineCount = (TestWorkspace.Buffers.BufferList[0].ByteBufferLength / 16) + 1;
+		if (TotalSize != 0) {
+			LineCount = (TotalSize / 16) + 1;
 		}
 		ScrollInfo.cbSize = sizeof(ScrollInfo);
 		ScrollInfo.fMask = SIF_POS;
@@ -399,6 +424,8 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		TextOut(DeviceContext, CharWidth * (47 + 12 + 3 + 14) - (HorizontalScrollPosition * CharWidth), 0, TEXT("E"), 1);
 		TextOut(DeviceContext, CharWidth * (47 + 12 + 3 + 15) - (HorizontalScrollPosition * CharWidth), 0, TEXT("F"), 1);
 
+		size_t AccumulatedBufferSize = 0;
+		size_t CurrentBuffer = 0;
 		for (int i = VerticalScrollPosition; i < LineCount; i++)
 		{
 			int Height = CharHeight * (i - VerticalScrollPosition + 1);
@@ -411,22 +438,25 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 			HRESULT Result = StringCbPrintf(Buffer, BufferSizeInBytes, TEXT("%08dx"), i);
 			TextOut(DeviceContext, -(HorizontalScrollPosition * CharWidth), Height, Buffer, BufferSizeInCharacters - 1);
 
-
 			int BytesOnThisLine = 16;
 			if (i == LineCount - 1)
 			{
-				BytesOnThisLine = TestWorkspace.Buffers.BufferList[0].ByteBufferLength % 16;
+				BytesOnThisLine = TotalSize % 16;
 			}
 
-			// TODO: Display the hex values
-			//TextOut(DeviceContext, CharWidth * 12, Height, "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00", 47);
-
-
-			// Display the hax & ASCII
+			// Display the hex & ASCII
 			const char* HexString = "0123456789ABCDEF";
 			for (int j = 0; j < BytesOnThisLine; j++)
 			{
-				const unsigned char CurrentChar = TestWorkspace.Buffers.BufferList[0].ByteBuffer[(i * 16) + j];
+				size_t BufferIndex = (i * 16) + j;
+				while (AccumulatedBufferSize + TestWorkspace.Buffers.BufferList[CurrentBuffer].ByteBufferLength <= BufferIndex)
+				{
+					AccumulatedBufferSize += TestWorkspace.Buffers.BufferList[CurrentBuffer].ByteBufferLength;
+					CurrentBuffer++;
+				}
+				BufferIndex -= AccumulatedBufferSize;
+
+				const unsigned char CurrentChar = TestWorkspace.Buffers.BufferList[CurrentBuffer].ByteBuffer[BufferIndex];
 				size_t HighNibble = CurrentChar >> 4;
 				size_t  LowNibble = CurrentChar & 0x0f;
 				TextOutA(DeviceContext, (CharWidth * (12 + (3 * j) + 0)) - (HorizontalScrollPosition * CharWidth), Height, &HexString[HighNibble], 1);
@@ -451,7 +481,12 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 			DragQueryFile((HDROP)wParam, i, Buffer, BufferCharacterCount);
 
 			TestWorkspace = maxHex::CreateWorkspaceFromFile(Buffer);
-			int LineCount = (TestWorkspace.Buffers.BufferList[0].ByteBufferLength / 16) + 1;
+			size_t TotalSize = 0;
+			for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+			{
+				TotalSize += CurrentBuffer.ByteBufferLength;
+			}
+			int LineCount = (TotalSize / 16) + 1;
 			SetScrollRange(WindowHandle, SB_VERT, 0, LineCount - 1, FALSE);
 			SetScrollPos(WindowHandle, SB_VERT, 0, TRUE);
 			UpdateWindow(WindowHandle);

--- a/Code/Workspace.cpp
+++ b/Code/Workspace.cpp
@@ -15,7 +15,7 @@ namespace maxHex
 	Workspace::Workspace(const Workspace& rhs) = default;
 	Workspace::Workspace(Workspace&& rhs) = default;
 
-	Workspace::Workspace(BufferChain&& Buffers)
+	Workspace::Workspace(BufferChain Buffers)
 		: Buffers(std::move(Buffers))
 	{
 	}
@@ -27,18 +27,30 @@ namespace maxHex
 	#if defined(MAX_PLATFORM_WINDOWS)
 	Workspace CreateWorkspaceFromFile(LPCTSTR FilePath)
 	{
+		File SourceFile(FilePath);
+		DWORD TotalSizeRead = 0;
+		size_t SourceOffset = 0;
+		std::vector<Buffer> FileBuffers;
+		const size_t ReadChunkSizeInBytes = 100;
+
 		HANDLE FileHandle = CreateFile(FilePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
 		DWORD FileSize = GetFileSize(FileHandle, NULL);
+		while (TotalSizeRead < FileSize) {
+			SourceOffset = TotalSizeRead;
+			FileBuffers.emplace_back(std::move(SourceFile), SourceOffset, 0, ReadChunkSizeInBytes);
 
-		File SourceFile(FilePath);
-		size_t SourceOffset = 0;
-		Buffer FileBuffer(std::move(SourceFile), std::move(SourceOffset), static_cast<size_t>(FileSize));
-		BufferChain FileBufferChain(std::move(FileBuffer));
-
-		void* buff = FileBufferChain.BufferList[0].ByteBuffer.get();
-		DWORD SizeRead;
-		ReadFile(FileHandle, (void*)buff, FileSize, &SizeRead, NULL);
+			void* buff = FileBuffers.back().ByteBuffer.get();
+			DWORD SizeRead = 0;
+			ReadFile(FileHandle, (void*)buff, ReadChunkSizeInBytes, &SizeRead, NULL);
+			FileBuffers.back().ByteBufferLength = SizeRead;
+			if (ReadChunkSizeInBytes != SizeRead) {
+				// TODO: Allow buffers to contain more data than they use
+			}
+			TotalSizeRead += SizeRead;
+		}
 		CloseHandle(FileHandle);
+
+		BufferChain FileBufferChain(std::move(FileBuffers));
 
 		return Workspace(std::move(FileBufferChain));
 	}

--- a/Code/Workspace.cpp
+++ b/Code/Workspace.cpp
@@ -31,7 +31,7 @@ namespace maxHex
 		DWORD TotalSizeRead = 0;
 		size_t SourceOffset = 0;
 		std::vector<Buffer> FileBuffers;
-		const size_t ReadChunkSizeInBytes = 100;
+		const size_t ReadChunkSizeInBytes = 4 * 1024;
 
 		HANDLE FileHandle = CreateFile(FilePath, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
 		DWORD FileSize = GetFileSize(FileHandle, NULL);

--- a/Code/Workspace.hpp
+++ b/Code/Workspace.hpp
@@ -22,7 +22,7 @@ namespace maxHex
 		Workspace();
 		Workspace(const Workspace& rhs);
 		Workspace(Workspace&& rhs);
-		explicit Workspace(BufferChain&& Buffers);
+		explicit Workspace(BufferChain Buffers);
 		~Workspace();
 
 		Workspace& operator =(const Workspace& rhs);


### PR DESCRIPTION
Previously, although there was a BufferChain class, only the first
buffer in the chain would be populated with the entire file. Other
code needed to be updated to allow multiple buffers.

This commit fixes the code which relied on using only one buffer
in the buffer chain and allows true multiple-buffer support.

Closes #3