### PR TITLE
Add buffer backing

### DIFF
--- a/Code/Buffer.cpp
+++ b/Code/Buffer.cpp
@@ -4,64 +4,40 @@
 
 #include "Buffer.hpp"
 
-#include <algorithm>
-#include <utility>
-
 namespace maxHex
 {
 
-	Buffer::Buffer(File SourceFile, size_t SourceOffset, const size_t BufferLength, const size_t BufferCapacity) noexcept
-		: SourceFile(std::move(SourceFile))
-		, SourceOffset(std::move(SourceOffset))
-		, ByteBuffer(std::make_unique<char[]>(BufferCapacity))
-		, ByteBufferLength(BufferLength)
-		, ByteBufferCapacity(BufferCapacity)
+	Buffer::Buffer(const BufferBacking Backing, const size_t Length, const size_t Capacity) noexcept
+		: Backing(Backing)
+		, Storage(std::make_unique<char[]>(Capacity))
+		, Length(Length)
+		, Capacity(Capacity)
 	{
 	}
 
 	Buffer::Buffer(const Buffer& rhs) noexcept
-		: SourceFile(rhs.SourceFile)
-		, SourceOffset(rhs.SourceOffset)
-		, ByteBuffer(std::make_unique<char[]>(rhs.ByteBufferCapacity))
-		, ByteBufferLength(rhs.ByteBufferLength)
-		, ByteBufferCapacity(rhs.ByteBufferCapacity)
+		: Backing(rhs.Backing)
+		, Storage(std::make_unique<char[]>(rhs.Capacity))
+		, Length(rhs.Length)
+		, Capacity(rhs.Capacity)
 	{
-		std::copy(rhs.ByteBuffer.get(), rhs.ByteBuffer.get() + rhs.ByteBufferLength, ByteBuffer.get());
+		std::copy(rhs.Storage.get(), rhs.Storage.get() + rhs.Length, Storage.get());
 	}
 
-	Buffer::Buffer(Buffer&& rhs) noexcept
-		: SourceFile(std::move(rhs.SourceFile))
-		, SourceOffset(std::move(rhs.SourceOffset))
-		, ByteBuffer(std::move(rhs.ByteBuffer))
-		, ByteBufferLength(std::move(rhs.ByteBufferLength))
-		, ByteBufferCapacity(std::move(rhs.ByteBufferCapacity))
-	{
-		rhs.ByteBuffer = nullptr;
-	}
+	Buffer::Buffer(Buffer&& rhs) noexcept = default;
+	Buffer::~Buffer() noexcept = default;
 
 	Buffer& Buffer::operator =(const Buffer& rhs) noexcept
 	{
-		SourceFile = rhs.SourceFile;
-		SourceOffset = rhs.SourceOffset;
-		ByteBuffer = std::make_unique<char[]>(rhs.ByteBufferCapacity);
-		ByteBufferLength = rhs.ByteBufferLength;
-		ByteBufferCapacity = rhs.ByteBufferCapacity;
+		Storage = std::make_unique<char[]>(rhs.Capacity);
+		Length = rhs.Length;
+		Capacity = rhs.Capacity;
 
-		std::copy(rhs.ByteBuffer.get(), rhs.ByteBuffer.get() + rhs.ByteBufferLength, ByteBuffer.get());
+		std::copy(rhs.Storage.get(), rhs.Storage.get() + rhs.Length, Storage.get());
 
 		return *this;
 	}
 
-	Buffer& Buffer::operator =(Buffer&& rhs) noexcept
-	{
-		SourceFile = std::move(rhs.SourceFile);
-		SourceOffset = std::move(rhs.SourceOffset);
-		ByteBuffer = std::move(rhs.ByteBuffer);
-		rhs.ByteBuffer = nullptr;
-		ByteBufferLength = std::move(rhs.ByteBufferLength);
-		ByteBufferCapacity = std::move(rhs.ByteBufferCapacity);
-
-		return *this;
-	}
+	Buffer& Buffer::operator =(Buffer&& rhs) noexcept = default;
 
 } // namespace maxHex

--- a/Code/Buffer.hpp
+++ b/Code/Buffer.hpp
@@ -5,7 +5,7 @@
 #ifndef MAXHEX_BUFFER_HPP
 #define MAXHEX_BUFFER_HPP
 
-#include "File.hpp"
+#include "BufferBacking.hpp"
 #include <memory>
 
 namespace maxHex
@@ -15,19 +15,18 @@ namespace maxHex
 	{
 	public:
 
-		Buffer(File SourceFile, size_t SourceOffset, const size_t BufferLength, const size_t BufferCapacity) noexcept;
+		Buffer(const BufferBacking Backing, const size_t Length, const size_t Capacity) noexcept;
 		Buffer(const Buffer& rhs) noexcept;
 		Buffer(Buffer&& rhs) noexcept;
-		~Buffer() noexcept = default;
+		~Buffer() noexcept;
 
 		Buffer& operator =(const Buffer& rhs) noexcept;
 		Buffer& operator =(Buffer&& rhs) noexcept;
 
-		File SourceFile;
-		size_t SourceOffset;
-		std::unique_ptr<char[]> ByteBuffer;
-		size_t ByteBufferLength;
-		size_t ByteBufferCapacity;
+		BufferBacking Backing;
+		std::unique_ptr<char[]> Storage;
+		size_t Length;
+		size_t Capacity;
 
 	};
 

--- a/Code/BufferBacking.hpp
+++ b/Code/BufferBacking.hpp
@@ -1,0 +1,14 @@
+// Copyright 2019, The maxHex Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+namespace maxHex
+{
+
+	enum class BufferBacking
+	{
+		File,
+		Memory,
+	};
+
+} // namespace maxHex

--- a/Code/BufferChain.cpp
+++ b/Code/BufferChain.cpp
@@ -4,24 +4,48 @@
 
 #include "BufferChain.hpp"
 #include <utility>
+#include <algorithm>
 
 namespace maxHex
 {
 
-	BufferChain::BufferChain()
+	BufferChain::BufferChain() noexcept
 		: BufferList()
 	{
 	}
 
-	BufferChain::BufferChain(Buffer InitialBuffer)
+	BufferChain::BufferChain(const BufferChain& rhs) noexcept
 		: BufferList()
 	{
-		BufferList.push_back(std::move(InitialBuffer));
+		BufferList.reserve(rhs.BufferList.size());
+		for (const std::unique_ptr<Buffer>& CurrentBuffer : rhs.BufferList)
+		{
+			auto CopiedBuffer = std::make_unique<Buffer>(*CurrentBuffer);
+			BufferList.push_back(std::move(CopiedBuffer));
+		}
 	}
 
-	BufferChain::BufferChain(std::vector<Buffer> BufferList)
+	BufferChain::BufferChain(BufferChain&& rhs) noexcept = default;
+	BufferChain::~BufferChain() noexcept = default;
+
+	BufferChain::BufferChain(std::vector<std::unique_ptr<Buffer>> BufferList) noexcept
 		: BufferList(std::move(BufferList))
 	{
 	}
+
+	BufferChain& BufferChain::operator =(const BufferChain& rhs) noexcept
+	{
+		BufferList = std::vector<std::unique_ptr<Buffer>>{};
+		BufferList.reserve(rhs.BufferList.size());
+		for (const std::unique_ptr<Buffer>& CurrentBuffer : rhs.BufferList)
+		{
+			auto CopiedBuffer = std::make_unique<Buffer>(*CurrentBuffer);
+			BufferList.push_back(std::move(CopiedBuffer));
+		}
+
+		return *this;
+	}
+
+	BufferChain& BufferChain::operator =(BufferChain&& rhs) noexcept = default;
 
 } // namespace maxHex

--- a/Code/BufferChain.hpp
+++ b/Code/BufferChain.hpp
@@ -7,6 +7,7 @@
 
 #include "Buffer.hpp"
 #include <vector>
+#include <memory>
 
 namespace maxHex
 {
@@ -15,11 +16,16 @@ namespace maxHex
 	{
 	public:
 
-		BufferChain();
-		explicit BufferChain(Buffer InitialBuffer);
-		explicit BufferChain(std::vector<Buffer> BufferList);
+		BufferChain() noexcept;
+		BufferChain(const BufferChain& rhs) noexcept;
+		BufferChain(BufferChain&& rhs) noexcept;
+		explicit BufferChain(std::vector<std::unique_ptr<Buffer>> BufferList) noexcept;
+		~BufferChain() noexcept;
 
-		std::vector<Buffer> BufferList;
+		BufferChain& operator =(const BufferChain& rhs) noexcept;
+		BufferChain& operator =(BufferChain&& rhs) noexcept;
+
+		std::vector<std::unique_ptr<Buffer>> BufferList;
 
 	};
 

--- a/Code/EntryPoint.cpp
+++ b/Code/EntryPoint.cpp
@@ -121,9 +121,9 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		MaxWidth = 72 * CharWidth; // TODO: Find real value
 
 		size_t TotalSize = 0;
-		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		for (const std::unique_ptr<maxHex::Buffer>& CurrentBuffer : TestWorkspace.Buffers.BufferList)
 		{
-			TotalSize += CurrentBuffer.ByteBufferLength;
+			TotalSize += CurrentBuffer->Length;
 		}
 		int LineCount = 0;
 		if (TotalSize != 0) {
@@ -141,9 +141,9 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 	case WM_SIZE:
 	{
 		size_t TotalSize = 0;
-		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		for (const std::unique_ptr<maxHex::Buffer>& CurrentBuffer : TestWorkspace.Buffers.BufferList)
 		{
-			TotalSize += CurrentBuffer.ByteBufferLength;
+			TotalSize += CurrentBuffer->Length;
 		}
 		int LineCount = 0;
 		if (TotalSize != 0) {
@@ -212,9 +212,9 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 
 
 		size_t TotalSize = 0;
-		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		for (const std::unique_ptr<maxHex::Buffer>& CurrentBuffer : TestWorkspace.Buffers.BufferList)
 		{
-			TotalSize += CurrentBuffer.ByteBufferLength;
+			TotalSize += CurrentBuffer->Length;
 		}
 		int LineCount = 0;
 		if (TotalSize != 0) {
@@ -331,9 +331,9 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		GetScrollInfo(WindowHandle, SB_VERT, &ScrollInfo);
 
 		size_t TotalSize = 0;
-		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		for (const std::unique_ptr<maxHex::Buffer>& CurrentBuffer : TestWorkspace.Buffers.BufferList)
 		{
-			TotalSize += CurrentBuffer.ByteBufferLength;
+			TotalSize += CurrentBuffer->Length;
 		}
 		int LineCount = 0;
 		if (TotalSize != 0) {
@@ -390,9 +390,9 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 		HFONT OldFont = (HFONT)SelectObject(DeviceContext, NewFont);
 
 		size_t TotalSize = 0;
-		for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+		for (const std::unique_ptr<maxHex::Buffer>& CurrentBuffer : TestWorkspace.Buffers.BufferList)
 		{
-			TotalSize += CurrentBuffer.ByteBufferLength;
+			TotalSize += CurrentBuffer->Length;
 		}
 		int LineCount = 0;
 		if (TotalSize != 0) {
@@ -449,14 +449,14 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 			for (int j = 0; j < BytesOnThisLine; j++)
 			{
 				size_t BufferIndex = (i * 16) + j;
-				while (AccumulatedBufferSize + TestWorkspace.Buffers.BufferList[CurrentBuffer].ByteBufferLength <= BufferIndex)
+				while (AccumulatedBufferSize + TestWorkspace.Buffers.BufferList[CurrentBuffer]->Length <= BufferIndex)
 				{
-					AccumulatedBufferSize += TestWorkspace.Buffers.BufferList[CurrentBuffer].ByteBufferLength;
+					AccumulatedBufferSize += TestWorkspace.Buffers.BufferList[CurrentBuffer]->Length;
 					CurrentBuffer++;
 				}
 				BufferIndex -= AccumulatedBufferSize;
 
-				const unsigned char CurrentChar = TestWorkspace.Buffers.BufferList[CurrentBuffer].ByteBuffer[BufferIndex];
+				const unsigned char CurrentChar = TestWorkspace.Buffers.BufferList[CurrentBuffer]->Storage[BufferIndex];
 				size_t HighNibble = CurrentChar >> 4;
 				size_t  LowNibble = CurrentChar & 0x0f;
 				TextOutA(DeviceContext, (CharWidth * (12 + (3 * j) + 0)) - (HorizontalScrollPosition * CharWidth), Height, &HexString[HighNibble], 1);
@@ -482,9 +482,9 @@ LRESULT CALLBACK WindowProcedure(HWND WindowHandle, UINT Message, WPARAM wParam,
 
 			TestWorkspace = maxHex::CreateWorkspaceFromFile(Buffer);
 			size_t TotalSize = 0;
-			for (const maxHex::Buffer& CurrentBuffer : TestWorkspace.Buffers.BufferList)
+			for (const std::unique_ptr<maxHex::Buffer>& CurrentBuffer : TestWorkspace.Buffers.BufferList)
 			{
-				TotalSize += CurrentBuffer.ByteBufferLength;
+				TotalSize += CurrentBuffer->Length;
 			}
 			int LineCount = (TotalSize / 16) + 1;
 			SetScrollRange(WindowHandle, SB_VERT, 0, LineCount - 1, FALSE);

--- a/Code/FileBackedBuffer.cpp
+++ b/Code/FileBackedBuffer.cpp
@@ -1,0 +1,26 @@
+// Copyright 2019, The maxHex Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "FileBackedBuffer.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace maxHex
+{
+
+	FileBackedBuffer::FileBackedBuffer(File SourceFile, size_t SourceOffset, const size_t BufferLength, const size_t BufferCapacity) noexcept
+		: Buffer(BufferBacking::File, BufferLength, BufferCapacity)
+		, SourceFile(std::move(SourceFile))
+		, SourceOffset(std::move(SourceOffset))
+	{
+	}
+
+	FileBackedBuffer::FileBackedBuffer(const FileBackedBuffer& rhs) noexcept = default;
+	FileBackedBuffer::FileBackedBuffer(FileBackedBuffer&& rhs) noexcept = default;
+	FileBackedBuffer::~FileBackedBuffer() noexcept = default;
+	FileBackedBuffer& FileBackedBuffer::operator =(const FileBackedBuffer& rhs) noexcept = default;
+	FileBackedBuffer& FileBackedBuffer::operator =(FileBackedBuffer&& rhs) noexcept = default;
+
+} // namespace maxHex

--- a/Code/FileBackedBuffer.hpp
+++ b/Code/FileBackedBuffer.hpp
@@ -1,0 +1,28 @@
+// Copyright 2019, The maxHex Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Buffer.hpp"
+#include "File.hpp"
+
+namespace maxHex
+{
+
+	class FileBackedBuffer : public Buffer
+	{
+	public:
+
+		FileBackedBuffer(File SourceFile, size_t SourceOffset, const size_t BufferLength, const size_t BufferCapacity) noexcept;
+		FileBackedBuffer(const FileBackedBuffer& rhs) noexcept;
+		FileBackedBuffer(FileBackedBuffer&& rhs) noexcept;
+		~FileBackedBuffer() noexcept;
+
+		FileBackedBuffer& operator =(const FileBackedBuffer& rhs) noexcept;
+		FileBackedBuffer& operator =(FileBackedBuffer&& rhs) noexcept;
+
+		File SourceFile;
+		size_t SourceOffset;
+
+	};
+
+} // namespace maxHex

--- a/Code/FileBackedBufferTests.cpp
+++ b/Code/FileBackedBufferTests.cpp
@@ -1,0 +1,168 @@
+// Copyright 2019, The maxHex Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "FileBackedBuffer.hpp"
+#include "File.hpp"
+#include <max/Testing/TestSuite.hpp>
+#include <max/Testing/CoutResultPolicy.hpp>
+#include <utility>
+#if defined(MAX_PLATFORM_WINDOWS)
+#include <Windows.h>
+#endif
+
+namespace maxHex
+{
+
+	void RunFileBackedBufferTestSuite()
+	{
+		max::Testing::CoutResultPolicy ResultPolicy;
+		auto BufferTestSuite = max::Testing::TestSuite< max::Testing::CoutResultPolicy >{ "maxHex::FileBackedBuffer test suite", std::move(ResultPolicy) };
+
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "constructor", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+#if defined(MAX_PLATFORM_WINDOWS)
+			LPCTSTR FilePath = TEXT("Test\\Path");
+			File TestFile(FilePath);
+#endif
+			size_t SourceOffset = 0;
+			const size_t BufferLength = 10;
+			const size_t BufferCapacity = 20;
+			FileBackedBuffer TestObject{ std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity };
+
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceFile.FilePath == FilePath);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceOffset == SourceOffset);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Backing == BufferBacking::File);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Storage != nullptr);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Length == BufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Capacity == BufferCapacity);
+			}
+		});
+
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy constructor", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+#if defined(MAX_PLATFORM_WINDOWS)
+			LPCTSTR FilePath = TEXT("Test\\Path");
+			File TestFile(FilePath);
+#endif
+			size_t SourceOffset = 0;
+			const size_t BufferLength = 10;
+			const size_t BufferCapacity = 20;
+			FileBackedBuffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
+
+			for (size_t i = 0; i < BufferLength; i++)
+			{
+				OriginalObject.Storage[i] = static_cast<char>(i);
+			}
+
+			FileBackedBuffer TestObject = OriginalObject;
+
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceFile.FilePath == OriginalObject.SourceFile.FilePath);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceOffset == OriginalObject.SourceOffset);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Backing == OriginalObject.Backing);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Length == OriginalObject.Length);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Capacity == OriginalObject.Capacity);
+			for (size_t i = 0; i < BufferLength; i++)
+			{
+				CurrentTest.MAX_TESTING_ASSERT(TestObject.Storage[i] == OriginalObject.Storage[i]);
+			}
+			}
+		});
+
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move constructor", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+#if defined(MAX_PLATFORM_WINDOWS)
+			LPCTSTR FilePath = TEXT("Test\\Path");
+			File TestFile(FilePath);
+#endif
+			size_t SourceOffset = 0;
+			const size_t BufferLength = 10;
+			const size_t BufferCapacity = 20;
+			FileBackedBuffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
+
+			const char* OriginalStorageAddress = OriginalObject.Storage.get();
+
+			FileBackedBuffer TestObject = std::move(OriginalObject);
+
+			CurrentTest.MAX_TESTING_ASSERT(OriginalObject.Storage == nullptr);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceFile.FilePath == FilePath);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceOffset == SourceOffset);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Backing == BufferBacking::File);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Storage.get() == OriginalStorageAddress);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Length == BufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Capacity == BufferCapacity);
+			}
+		});
+
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "copy assignment operator", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+#if defined(MAX_PLATFORM_WINDOWS)
+			LPCTSTR FilePath = TEXT("Test\\Path");
+			File TestFile(FilePath);
+#endif
+			size_t SourceOffset = 0;
+			const size_t BufferLength = 10;
+			const size_t BufferCapacity = 20;
+			FileBackedBuffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
+
+			for (size_t i = 0; i < BufferLength; i++)
+			{
+				OriginalObject.Storage[i] = static_cast<char>(i);
+			}
+
+#if defined(MAX_PLATFORM_WINDOWS)
+			LPCTSTR SecondFilePath = TEXT("Test\\Path");
+			File SecondTestFile(SecondFilePath);
+#endif
+			size_t SecondSourceOffset = 30;
+			const size_t SecondBufferLength = 40;
+			const size_t SecondBufferCapacity = 50;
+			FileBackedBuffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), SecondBufferLength, SecondBufferCapacity);
+			TestObject = OriginalObject;
+
+
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceFile.FilePath == OriginalObject.SourceFile.FilePath);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceOffset == OriginalObject.SourceOffset);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Backing == OriginalObject.Backing);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Length == OriginalObject.Length);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Capacity == OriginalObject.Capacity);
+			for (size_t i = 0; i < BufferLength; i++)
+			{
+				CurrentTest.MAX_TESTING_ASSERT(TestObject.Storage[i] == OriginalObject.Storage[i]);
+			}
+			}
+		});
+
+		BufferTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "move assignment operator", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+#if defined(MAX_PLATFORM_WINDOWS)
+			LPCTSTR FilePath = TEXT("Test\\Path");
+			File TestFile(FilePath);
+#endif
+			size_t SourceOffset = 0;
+			const size_t BufferLength = 10;
+			const size_t BufferCapacity = 20;
+			FileBackedBuffer OriginalObject(std::move(TestFile), std::move(SourceOffset), BufferLength, BufferCapacity);
+			const char* OriginalStorageAddress = OriginalObject.Storage.get();
+
+#if defined(MAX_PLATFORM_WINDOWS)
+			LPCTSTR SecondFilePath = TEXT("Test\\Path");
+			File SecondTestFile(SecondFilePath);
+#endif
+			size_t SecondSourceOffset = 30;
+			const size_t SecondBufferLength = 40;
+			const size_t SecondBufferCapacity = 50;
+
+			FileBackedBuffer TestObject(std::move(SecondTestFile), std::move(SecondSourceOffset), SecondBufferLength, SecondBufferCapacity);
+
+			TestObject = std::move(OriginalObject);
+
+			CurrentTest.MAX_TESTING_ASSERT(OriginalObject.Storage == nullptr);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Storage.get() == OriginalStorageAddress);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceFile.FilePath == FilePath);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.SourceOffset == SourceOffset);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Backing == BufferBacking::File);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Length == BufferLength);
+			CurrentTest.MAX_TESTING_ASSERT(TestObject.Capacity == BufferCapacity);
+			}
+		});
+
+		BufferTestSuite.RunTests();
+	}
+
+} // namespace maxHex

--- a/Code/FileBackedBufferTests.hpp
+++ b/Code/FileBackedBufferTests.hpp
@@ -1,0 +1,10 @@
+// Copyright 2019, The maxHex Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+namespace maxHex
+{
+
+	void RunFileBackedBufferTestSuite();
+
+} // namespace maxHex

--- a/Code/FileTests.cpp
+++ b/Code/FileTests.cpp
@@ -14,7 +14,7 @@ namespace maxHex
 		max::Testing::CoutResultPolicy ResultPolicy;
 		auto FileTestSuite = max::Testing::TestSuite< max::Testing::CoutResultPolicy >{ "maxHex::File test suite", std::move(ResultPolicy) };
 
-		FileTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "constructor copies path", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
+		FileTestSuite.AddTest(max::Testing::Test< max::Testing::CoutResultPolicy >{ "constructor", [](max::Testing::Test< max::Testing::CoutResultPolicy >& CurrentTest, max::Testing::CoutResultPolicy const& ResultPolicy) {
 			#if defined(MAX_PLATFORM_WINDOWS)
 			LPCTSTR FilePath = TEXT("Test\Path");
 			File TestObject(FilePath);

--- a/Code/TestEntryPoint.cpp
+++ b/Code/TestEntryPoint.cpp
@@ -4,12 +4,14 @@
 
 #include "BufferTests.hpp"
 #include "BufferChainTests.hpp"
+#include "FileBackedBufferTests.hpp"
 #include "FileTests.hpp"
 
 int main()
 {
 	maxHex::RunBufferTestSuite();
 	maxHex::RunBufferChainTestSuite();
+	maxHex::RunFileBackedBufferTestSuite();
 	maxHex::RunFileTestSuite();
 
 	return 0;

--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj
@@ -33,12 +33,15 @@
     <ClCompile Include="..\..\..\Code\Buffer.cpp" />
     <ClCompile Include="..\..\..\Code\BufferChain.cpp" />
     <ClCompile Include="..\..\..\Code\File.cpp" />
+    <ClCompile Include="..\..\..\Code\FileBackedBuffer.cpp" />
     <ClCompile Include="..\..\..\Code\Workspace.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\Buffer.hpp" />
+    <ClInclude Include="..\..\..\Code\BufferBacking.hpp" />
     <ClInclude Include="..\..\..\Code\BufferChain.hpp" />
     <ClInclude Include="..\..\..\Code\File.hpp" />
+    <ClInclude Include="..\..\..\Code\FileBackedBuffer.hpp" />
     <ClInclude Include="..\..\..\Code\Workspace.hpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClCompile Include="..\..\..\Code\Workspace.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Code\FileBackedBuffer.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\Buffer.hpp">
@@ -73,6 +76,12 @@
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Code\Workspace.hpp">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Code\BufferBacking.hpp">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Code\FileBackedBuffer.hpp">
       <Filter>Code</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
+++ b/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
@@ -21,12 +21,14 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\Code\BufferChainTests.cpp" />
     <ClCompile Include="..\..\..\Code\BufferTests.cpp" />
+    <ClCompile Include="..\..\..\Code\FileBackedBufferTests.cpp" />
     <ClCompile Include="..\..\..\Code\FileTests.cpp" />
     <ClCompile Include="..\..\..\Code\TestEntryPoint.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\BufferChainTests.hpp" />
     <ClInclude Include="..\..\..\Code\BufferTests.hpp" />
+    <ClInclude Include="..\..\..\Code\FileBackedBufferTests.hpp" />
     <ClInclude Include="..\..\..\Code\FileTests.hpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj.filters
+++ b/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj.filters
@@ -4,11 +4,13 @@
     <ClInclude Include="..\..\..\Code\BufferTests.hpp" />
     <ClInclude Include="..\..\..\Code\BufferChainTests.hpp" />
     <ClInclude Include="..\..\..\Code\FileTests.hpp" />
+    <ClInclude Include="..\..\..\Code\FileBackedBufferTests.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Code\BufferTests.cpp" />
     <ClCompile Include="..\..\..\Code\TestEntryPoint.cpp" />
     <ClCompile Include="..\..\..\Code\BufferChainTests.cpp" />
     <ClCompile Include="..\..\..\Code\FileTests.cpp" />
+    <ClCompile Include="..\..\..\Code\FileBackedBufferTests.cpp" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently, a workspace can be split across multiple buffers. This
is good for allowing files to be loaded in chunks (potentially
lazily). But it is also good for inserting a buffer in the middle
when the user types.

However, all buffers were previously assumed to be loaded from a
file. This becomes a problem if we decide to lazy load. Maybe that
chunk will exist but hasn't been loaded yet.

Additionally, we needed a way to indicate whether a buffer can be
purged to save memory or if it is in memory from what the user
typed/pasted.

This commit adds buffer backing to indicate what the buffer's
contents are from.

Contributes to #4 and #29