### PR TITLE
Fix window width calculation

### DIFF
--- a/Code/Window.cpp
+++ b/Code/Window.cpp
@@ -369,16 +369,29 @@ namespace
 
 
 		HDC DeviceContext = CreateCompatibleDC(NULL);
-		HFONT NewFont = (HFONT)GetStockObject(SYSTEM_FIXED_FONT);
+
+		// Windows Vista+ comes with Consolas
+		LOGFONT lf = { 0 };
+		for (size_t i = 0; i < 9; i++) {
+			lf.lfFaceName[i] = "Consolas"[i];
+		}
+		lf.lfHeight = 14;
+		HFONT NewFont = CreateFontIndirect(&lf);
+		if (NewFont == NULL)
+		{
+			NewFont = (HFONT)GetStockObject(SYSTEM_FIXED_FONT);
+		}
 		HFONT OldFont = (HFONT)SelectObject(DeviceContext, NewFont);
 
 		TEXTMETRIC TextMetrics;
 		GetTextMetrics(DeviceContext, &TextMetrics);
 		int CharWidth = TextMetrics.tmAveCharWidth;
-		CharWidth++; // Ave seems not great
 		int CharHeight = TextMetrics.tmHeight + TextMetrics.tmExternalLeading;
 
-		int ClientWidth = CharWidth * 72;
+		int VerticalScrollBarWidth = GetSystemMetrics(SM_CXVSCROLL);
+		//int HorizontalScrollBarHeight = GetSystemMetrics(SM_CXVSCROLL);
+
+		int ClientWidth = CharWidth * 78 + VerticalScrollBarWidth;
 		int ClientHeight = CharHeight * 40;
 		SelectObject(DeviceContext, OldFont);
 		DeleteObject(DeviceContext);


### PR DESCRIPTION
Previously, the window width was calculated based off character
width only. It added padding for the vertical scroll bar.

This meant it was guestimating how many characters would make up
one scroll bar's width. This was a silly thing to do.

This commit gets the actual scroll bar width and sets the window
width to the correct amount.