### PR TITLE
Fix Rasterizer style

### DIFF
--- a/Code/Rasterizer.cpp
+++ b/Code/Rasterizer.cpp
@@ -138,7 +138,6 @@ namespace maxHex
 		}
 
 		SelectObject(DeviceContext, OldFont);
-
 	}
 	#endif
 

--- a/Code/Rasterizer.hpp
+++ b/Code/Rasterizer.hpp
@@ -1,5 +1,5 @@
-#ifndef MAXHEX_RASTERER_HPP
-#define MAXHEX_RASTERER_HPP
+#ifndef MAXHEX_RASTERIZER_HPP
+#define MAXHEX_RASTERIZER_HPP
 
 #include <max/Compiling/Configuration.hpp>
 
@@ -39,4 +39,4 @@ namespace maxHex
 
 } // namespace maxHex
 
-#endif // #ifndef MAXHEX_RASTERER_HPP
+#endif // #ifndef MAXHEX_RASTERIZER_HPP


### PR DESCRIPTION
During initial Rasterizer development it was going to be named
Rasterer. The include guard used this name and was not updated when
the name was changed to Rasterizer.

Additionally, the bottom of the Rasterize function had a blank
line.

This commit fixes both of those issues.