### PR TITLE
Add font holder

### DIFF
--- a/Code/Font.cpp
+++ b/Code/Font.cpp
@@ -1,0 +1,47 @@
+#include "Font.hpp"
+
+namespace maxHex
+{
+
+	Font Font::Create(const std::string& Name, long Size) noexcept
+	{
+		// Windows Vista+ comes with Consolas
+		LOGFONT lf = { 0 };
+		for (size_t i = 0; i < Name.size(); i++) {
+			lf.lfFaceName[i] = Name[i];
+		}
+		lf.lfHeight = Size;
+		HFONT NewFont = CreateFontIndirect(&lf);
+		return Font(NewFont);
+	}
+
+	#if defined(MAX_PLATFORM_WINDOWS)
+	Font::Font(HFONT font) noexcept
+		: font(font)
+	{
+	}
+	#endif
+
+	Font::Font(Font&& rhs) noexcept
+		: font(rhs.font)
+	{
+		rhs.font = NULL;
+	}
+
+	Font::~Font() noexcept
+	{
+		if (font != NULL)
+		{
+			DeleteObject(font);
+		}
+	}
+
+	Font& Font::operator =(Font&& rhs) noexcept
+	{
+		font = rhs.font;
+		rhs.font = NULL;
+
+		return *this;
+	}
+
+} // namespace maxHex

--- a/Code/Font.hpp
+++ b/Code/Font.hpp
@@ -1,0 +1,45 @@
+#ifndef MAXHEX_FONT_HPP
+#define MAXHEX_FONT_HPP
+
+#include <max/Compiling/Configuration.hpp>
+
+#include <string>
+
+#if defined(MAX_PLATFORM_WINDOWS)
+#include <Windows.h>
+#endif
+
+namespace maxHex
+{
+
+	class Font
+	{
+	public:
+
+		static Font Create(const std::string& Name, long Size) noexcept;
+
+		Font() = delete;
+		#if defined(MAX_PLATFORM_WINDOWS)
+		explicit Font(HFONT font) noexcept;
+		#endif
+		// TODO: Duplicating a font is a pain. Skipping for now.
+		Font(const Font&) = delete;
+		Font(Font&& rhs) noexcept;
+
+		~Font() noexcept;
+
+		// TODO: Duplicating a font is a pain. Skipping for now.
+		Font& operator =(const Font&) = delete;
+		Font& operator =(Font&& rhs) noexcept;
+
+		//private:
+
+		#if defined(MAX_PLATFORM_WINDOWS)
+		HFONT font;
+		#endif
+
+	};
+
+} // namespace maxHex
+
+#endif // #ifndef MAXHEX_FONT_HPP

--- a/Code/Rasterizer.cpp
+++ b/Code/Rasterizer.cpp
@@ -5,8 +5,10 @@
 namespace maxHex
 {
 
-	Rasterizer Rasterizer::Create(HDC DeviceContext) noexcept
+	Rasterizer Rasterizer::Create(HDC DeviceContext, const maxHex::Font& font) noexcept
 	{
+		SelectObject(DeviceContext, font.font);
+
 		TEXTMETRIC TextMetrics;
 		GetTextMetrics(DeviceContext, &TextMetrics);
 		int CharacterHeight = TextMetrics.tmHeight + TextMetrics.tmExternalLeading;
@@ -22,21 +24,8 @@ namespace maxHex
 	}
 
 	#if defined(MAX_PLATFORM_WINDOWS)
-	void Rasterizer::Rasterize(HWND WindowHandle,HDC DeviceContext, int VirtualTop, int VirtualLeft, int Height, int Width, const BufferChain& Buffers, const UserInteractionState& InteractionState) noexcept
+	void Rasterizer::Rasterize(HWND WindowHandle, HDC DeviceContext, int VirtualTop, int VirtualLeft, int Height, int Width, const BufferChain& Buffers, const UserInteractionState& InteractionState) noexcept
 	{
-		// Windows Vista+ comes with Consolas
-		LOGFONT lf = { 0 };
-		for (size_t i = 0; i < 9; i++) {
-			lf.lfFaceName[i] = "Consolas"[i];
-		}
-		lf.lfHeight = 14;
-		HFONT NewFont = CreateFontIndirect(&lf);
-		if (NewFont == NULL)
-		{
-			NewFont = (HFONT)GetStockObject(SYSTEM_FIXED_FONT);
-		}
-		HFONT OldFont = (HFONT)SelectObject(DeviceContext, NewFont);
-
 		RECT BlankRect;
 		BlankRect.top = VirtualTop;
 		BlankRect.left = VirtualLeft;
@@ -136,8 +125,6 @@ namespace maxHex
 				TextOutA(DeviceContext, (CharacterWidth * (47 + 12 + 3 + j)) - (InteractionState.HorizontalScrollOffset * CharacterWidth), Height, reinterpret_cast<const char*>(&CurrentChar), 1);
 			}
 		}
-
-		SelectObject(DeviceContext, OldFont);
 	}
 	#endif
 

--- a/Code/Rasterizer.hpp
+++ b/Code/Rasterizer.hpp
@@ -7,6 +7,7 @@
 #include <Windows.h>
 #endif
 #include "BufferChain.hpp"
+#include "Font.hpp"
 #include "UserInteractionState.hpp"
 
 namespace maxHex
@@ -16,7 +17,7 @@ namespace maxHex
 	{
 	public:
 
-		static Rasterizer Create(HDC DeviceContext) noexcept;
+		static Rasterizer Create(HDC DeviceContext, const maxHex::Font& font) noexcept;
 
 		Rasterizer() = delete;
 		Rasterizer(int CharacterHeight, int CharacterWidth) noexcept;

--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj
@@ -34,6 +34,7 @@
     <ClCompile Include="..\..\..\Code\BufferChain.cpp" />
     <ClCompile Include="..\..\..\Code\File.cpp" />
     <ClCompile Include="..\..\..\Code\FileBackedBuffer.cpp" />
+    <ClCompile Include="..\..\..\Code\Font.cpp" />
     <ClCompile Include="..\..\..\Code\Rasterizer.cpp" />
     <ClCompile Include="..\..\..\Code\UserInteractionState.cpp" />
     <ClCompile Include="..\..\..\Code\Window.cpp" />
@@ -45,6 +46,7 @@
     <ClInclude Include="..\..\..\Code\BufferChain.hpp" />
     <ClInclude Include="..\..\..\Code\File.hpp" />
     <ClInclude Include="..\..\..\Code\FileBackedBuffer.hpp" />
+    <ClInclude Include="..\..\..\Code\Font.hpp" />
     <ClInclude Include="..\..\..\Code\Rasterizer.hpp" />
     <ClInclude Include="..\..\..\Code\UserInteractionState.hpp" />
     <ClInclude Include="..\..\..\Code\Window.hpp" />

--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClCompile Include="..\..\..\Code\Rasterizer.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Code\Font.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\Buffer.hpp">
@@ -100,6 +103,9 @@
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Code\Rasterizer.hpp">
+      <Filter>Code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\Code\Font.hpp">
       <Filter>Code</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Previously, we were creating fonts multiple times as we needed
them. They were not reused. This includes inside the rasterization,
which should be fast.

This commit adds a font holder which allows us to create a font
once and reuse it between rasters.