### PR TITLE
Don't create separate library

### DIFF
--- a/Projects/VisualStudio/maxHex.sln
+++ b/Projects/VisualStudio/maxHex.sln
@@ -4,14 +4,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "maxHexAutomatedTests", "maxHexAutomatedTests\maxHexAutomatedTests.vcxproj", "{6A065CC4-6489-4844-B45B-5B32FCC45D70}"
-	ProjectSection(ProjectDependencies) = postProject
-		{5C96E8F6-8EA1-40B3-8418-1171FE5617BE} = {5C96E8F6-8EA1-40B3-8418-1171FE5617BE}
-	EndProjectSection
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "maxHexExecutable", "maxHexExecutable\maxHexExecutable.vcxproj", "{07E81854-25B2-4058-B546-D9712CA4CE64}"
-	ProjectSection(ProjectDependencies) = postProject
-		{5C96E8F6-8EA1-40B3-8418-1171FE5617BE} = {5C96E8F6-8EA1-40B3-8418-1171FE5617BE}
-	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "maxHex", "maxHex\maxHex.vcxproj", "{5C96E8F6-8EA1-40B3-8418-1171FE5617BE}"
 EndProject
@@ -31,14 +23,6 @@ Global
 		{6A065CC4-6489-4844-B45B-5B32FCC45D70}.Release|Win32.Build.0 = Release|Win32
 		{6A065CC4-6489-4844-B45B-5B32FCC45D70}.Release|x64.ActiveCfg = Release|x64
 		{6A065CC4-6489-4844-B45B-5B32FCC45D70}.Release|x64.Build.0 = Release|x64
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Debug|Win32.ActiveCfg = Debug|Win32
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Debug|Win32.Build.0 = Debug|Win32
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Debug|x64.ActiveCfg = Debug|x64
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Debug|x64.Build.0 = Debug|x64
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Release|Win32.ActiveCfg = Release|Win32
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Release|Win32.Build.0 = Release|Win32
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Release|x64.ActiveCfg = Release|x64
-		{07E81854-25B2-4058-B546-D9712CA4CE64}.Release|x64.Build.0 = Release|x64
 		{5C96E8F6-8EA1-40B3-8418-1171FE5617BE}.Debug|Win32.ActiveCfg = Debug|Win32
 		{5C96E8F6-8EA1-40B3-8418-1171FE5617BE}.Debug|Win32.Build.0 = Debug|Win32
 		{5C96E8F6-8EA1-40B3-8418-1171FE5617BE}.Debug|x64.ActiveCfg = Debug|x64

--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\Code\Buffer.cpp" />
     <ClCompile Include="..\..\..\Code\BufferChain.cpp" />
+    <ClCompile Include="..\..\..\Code\EntryPoint.cpp" />
     <ClCompile Include="..\..\..\Code\File.cpp" />
     <ClCompile Include="..\..\..\Code\FileBackedBuffer.cpp" />
     <ClCompile Include="..\..\..\Code\Font.cpp" />
@@ -64,26 +65,26 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -113,7 +114,7 @@
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <ExecutablePath>$(VC_ExecutablePath_x64);$(CommonExecutablePath)</ExecutablePath>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Code;$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</LibraryPath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
@@ -121,7 +122,7 @@
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <ExecutablePath>$(VC_ExecutablePath_x86);$(CommonExecutablePath)</ExecutablePath>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Code;$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</LibraryPath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -129,7 +130,7 @@
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <ExecutablePath>$(VC_ExecutablePath_x86);$(CommonExecutablePath)</ExecutablePath>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Code;$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</LibraryPath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -137,7 +138,7 @@
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <ExecutablePath>$(VC_ExecutablePath_x64);$(CommonExecutablePath)</ExecutablePath>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Code;$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</LibraryPath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
+++ b/Projects/VisualStudio/maxHex/maxHex.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="..\..\..\Code\Font.cpp">
       <Filter>Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Code\EntryPoint.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\Code\Buffer.hpp">

--- a/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
+++ b/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj
@@ -19,16 +19,24 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\Code\Buffer.cpp" />
+    <ClCompile Include="..\..\..\Code\BufferChain.cpp" />
     <ClCompile Include="..\..\..\Code\BufferChainTests.cpp" />
     <ClCompile Include="..\..\..\Code\BufferTests.cpp" />
+    <ClCompile Include="..\..\..\Code\File.cpp" />
+    <ClCompile Include="..\..\..\Code\FileBackedBuffer.cpp" />
     <ClCompile Include="..\..\..\Code\FileBackedBufferTests.cpp" />
     <ClCompile Include="..\..\..\Code\FileTests.cpp" />
     <ClCompile Include="..\..\..\Code\TestEntryPoint.cpp" />
     <ClCompile Include="..\..\..\Dependencies\max\Code\max\Testing\CoutResultPolicy.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\Code\Buffer.hpp" />
+    <ClInclude Include="..\..\..\Code\BufferChain.hpp" />
     <ClInclude Include="..\..\..\Code\BufferChainTests.hpp" />
     <ClInclude Include="..\..\..\Code\BufferTests.hpp" />
+    <ClInclude Include="..\..\..\Code\File.hpp" />
+    <ClInclude Include="..\..\..\Code\FileBackedBuffer.hpp" />
     <ClInclude Include="..\..\..\Code\FileBackedBufferTests.hpp" />
     <ClInclude Include="..\..\..\Code\FileTests.hpp" />
   </ItemGroup>
@@ -87,28 +95,28 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(MSBuildProjectDirectory)\..\maxHex\$(Platform)\$(Configuration)\;$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(MSBuildProjectDirectory)\..\maxHex\$(Platform)\$(Configuration)\;$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(MSBuildProjectDirectory)\..\maxHex\$(Platform)\$(Configuration)\;$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(MSBuildProjectDirectory)\..\..\..\Dependencies\max\Code;$(IncludePath)</IncludePath>
-    <LibraryPath>$(MSBuildProjectDirectory)\..\maxHex\$(Platform)\$(Configuration)\;$(MSBuildProjectDirectory)\..\max\$(Platform)\$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
@@ -127,7 +135,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>maxHex.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -145,7 +153,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>maxHex.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -167,7 +175,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>maxHex.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -189,7 +197,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>maxHex.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj.filters
+++ b/Projects/VisualStudio/maxHexAutomatedTests/maxHexAutomatedTests.vcxproj.filters
@@ -5,6 +5,10 @@
     <ClInclude Include="..\..\..\Code\BufferChainTests.hpp" />
     <ClInclude Include="..\..\..\Code\FileTests.hpp" />
     <ClInclude Include="..\..\..\Code\FileBackedBufferTests.hpp" />
+    <ClInclude Include="..\..\..\Code\BufferChain.hpp" />
+    <ClInclude Include="..\..\..\Code\Buffer.hpp" />
+    <ClInclude Include="..\..\..\Code\FileBackedBuffer.hpp" />
+    <ClInclude Include="..\..\..\Code\File.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Code\BufferTests.cpp" />
@@ -15,6 +19,10 @@
     <ClCompile Include="..\..\..\Dependencies\max\Code\max\Testing\CoutResultPolicy.cpp">
       <Filter>Dependencies\max\Testing</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Code\BufferChain.cpp" />
+    <ClCompile Include="..\..\..\Code\Buffer.cpp" />
+    <ClCompile Include="..\..\..\Code\FileBackedBuffer.cpp" />
+    <ClCompile Include="..\..\..\Code\File.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Dependencies">


### PR DESCRIPTION
Previously, maxHex was a library. A separate project was an executable that depended on the library. The intent was to eventually have a console executable and a GUI executable.

However, that intent can still be met without needing a library. The code can be built twice (one for each executable).

Perhaps building twice will increase build times enough to want a common library again. But let's cross that bridge when we get there.